### PR TITLE
fix(sdk): update download page

### DIFF
--- a/templates/pages/sdk_down.html
+++ b/templates/pages/sdk_down.html
@@ -25,16 +25,18 @@
     <div style="display:flex;flex-wrap:wrap;margin-left:-20px">
       <div class="dl-cell">
         <div class="desc">
-          <h2><i class="icon icon-github"></i> Objective-C</h2>
+          <h2><i class="icon icon-github"></i> iOS</h2>
           <p>
             Includes LeanStorage, LeanMessage, Push Notifications, In-App Socializing, User Feedback, In-App Searching,
-            etc. <a href="https://releases.leanapp.cn/#/leancloud/objc-sdk/releases">View All</a>
+            etc.
           </p>
         </div>
         <ul class="list-unstyled list-inline download-btns">
-          <li><a href="https://releases.leanapp.cn/#/leancloud/objc-sdk/releases"
+          <li><a href="https://github.com/leancloud/objc-sdk/"
               class="btn btn-sm btn-primary">Objective-C SDK</a></li>
-          <li><a href="https://releases.leanapp.cn/#/leancloud/leancloud-feedback-ios/releases" class="btn btn-link">
+          <li><a href="https://github.com/leancloud/swift-sdk/"
+              class="btn btn-sm btn-primary">Swift SDK</a></li>
+          <li><a href="https://github.com/leancloud/leancloud-feedback-ios/" class="btn btn-link">
               User Feedback Components</a></li>
         </ul>
       </div>
@@ -46,10 +48,10 @@
           </p>
         </div>
         <ul class="list-unstyled list-inline download-btns">
-          <li><a href="https://releases.leanapp.cn/#/leancloud/javascript-sdk/releases" class="btn btn-sm btn-primary">
+          <li><a href="https://github.com/leancloud/javascript-sdk/" class="btn btn-sm btn-primary">
               LeanStorage SDK</a>
           </li>
-          <li><a href="https://releases.leanapp.cn/#/leancloud/js-realtime-sdk/releases" class="btn btn-sm btn-primary">
+          <li><a href="https://github.com/leancloud/js-realtime-sdk/" class="btn btn-sm btn-primary">
               LeanMessage SDK</a>
           </li>
         </ul>
@@ -63,19 +65,19 @@
         </div>
         <ul class="list-inline">
           <li>
-            <a href="https://github.com/leancloud/java-unified-sdk/releases" class="btn btn-sm btn-primary">Java SDK</a>
+            <a href="https://github.com/leancloud/java-unified-sdk/" class="btn btn-sm btn-primary">Java SDK</a>
           </li>
         </ul>
       </div>
       <div class="dl-cell">
         <div class="desc">
           <h2><i class="icon icon-github"></i> Other SDKs</h2>
+          <p>Intented to be used at server side.</p>
         </div>
         <ul class="list-unstyled list-inline download-btns">
-          <li><a href="https://releases.leanapp.cn/#/leancloud/python-sdk/releases" class="btn btn-link"> Python SDK</a>
+          <li><a href="https://github.com/leancloud/python-sdk/" class="btn btn-link"> Python SDK</a>
           </li>
-          <li><a href="https://releases.leanapp.cn/#/leancloud/php-sdk/releases" class="btn btn-link"> PHP SDK</a></li>
-          <li><a href="https://github.com/leancloud/swift-sdk" class="btn btn-link"> Swift SDK</a></li>
+          <li><a href="https://github.com/leancloud/php-sdk/" class="btn btn-link"> PHP SDK</a></li>
         </ul>
       </div>
       <div class="dl-cell" style="border-color:transparent;"></div>


### PR DESCRIPTION
1. Link to GitHub directly instead of  releases.leanapp.cn,
since global users typically have no difficulties to access GitHub.
2. Do not list old versions of SDKs.

see also leancloud/docs#3128/